### PR TITLE
Make sure that task runs always

### DIFF
--- a/plugin/src/main/kotlin/io/github/bjoernmayer/gradleProjectDependents/ProjectDependentsGradlePlugin.kt
+++ b/plugin/src/main/kotlin/io/github/bjoernmayer/gradleProjectDependents/ProjectDependentsGradlePlugin.kt
@@ -19,6 +19,8 @@ public class ProjectDependentsGradlePlugin : Plugin<Project> {
                 task.generateYamlGraph = true
                 task.outputFile.set(target.layout.buildDirectory.file("projectDependents/graph.yaml"))
             }
+
+            task.outputs.upToDateWhen { false }
         }
     }
 }


### PR DESCRIPTION
This pr sets `task.outputs.upToDateWhen { false }` so the task runs everytime